### PR TITLE
Create a document HTML template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ org_usage.csv
 node_modules
 .next
 out
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -2807,9 +2807,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.442",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.442.tgz",
-      "integrity": "sha512-3OjmbnD9+LyWzh9o3rjC7LNIkcDHjKyHM6Xt0G/+7gHGCaEIwvWYi8TrNA8feNnuGmvI9WKu289PFMQGMLHAig=="
+      "version": "1.3.443",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.443.tgz",
+      "integrity": "sha512-ty0LEroTap/xfMy31oQ3XX+Q377QvWvJaha2cmuXcbmBiX2EIB5SNDQ0hp8lhvxj63WG0zOgm/4MQ/oUBdfQqg=="
     },
     "elliptic": {
       "version": "6.5.2",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,45 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class GovukTemplate extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html lang='en' className='govuk-template'>
+        <Head />
+        <body className="govuk-template__body">
+        <a href="#main-content" className="govuk-skip-link">Skip to main content</a>
+          <header className="govuk-header " role="banner" data-module="govuk-header">
+            <div className="govuk-header__container govuk-width-container">
+              <div className="govuk-header__logo">
+                <a href="/" className="govuk-header__link govuk-header__link--homepage">
+                  <span className="govuk-header__logotype">
+                    <svg aria-hidden="true" focusable="false" className="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                      <path fill="currentColor" fillRule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                      <image src="/assets/images/govuk-logotype-crown.png" className="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+                    </svg>
+                    <span className="govuk-header__logotype-text">
+                      GOV.UK
+                    </span>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </header>
+          <div className="govuk-width-container">
+            <main className="govuk-main-wrapper" id="main-content" role="main">
+              <Main />
+            </main>
+          </div>
+          {/* footer goes here */}
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default GovukTemplate


### PR DESCRIPTION
## What

For our pages to have a GOV.UK look to them, we need to use the template from [GOV.UK Design System](https://design-system.service.gov.uk/styles/page-template/)

To do this in NextJS apps we need to declare a custom `Document`
as described in [NextJS docs](https://nextjs.org/docs/advanced-features/custom-document)

This will add the necessary HTML markup to our pages, but they still won't be styled.

**Before**
<img width="627" alt="before" src="https://user-images.githubusercontent.com/3758555/82304939-e6966380-99b4-11ea-85d0-9d301a3e017a.png">

**After**
<img width="761" alt="after" src="https://user-images.githubusercontent.com/3758555/82304935-e5fdcd00-99b4-11ea-8a81-49717b3ad389.png">

## How to review

- clone project
- optional: install node if you don't have it already
- install dependencies with `npm install`
- run `npm run dev` to build the app
- go to http://localhost:3000 to view the page
- Check you see the update HTML markup from `pages/_document.js`

