### PR TITLE
Create a Footer component

### DIFF
--- a/components/Footer/data.json
+++ b/components/Footer/data.json
@@ -1,0 +1,28 @@
+{
+  "navigation": [],
+  "meta": {
+    "visuallyHiddenTitle" : "Support links",
+    "items": [
+      { 
+        "text": "Built by Government Digital Service", 
+        "href": "https://www.gov.uk/government/organisations/government-digital-service"
+      },
+      { 
+        "text": "Cookies", 
+        "href": "/cookies"
+      },
+      { 
+        "text": "Privacy notice", 
+        "href": "/privacy-notice"
+      },
+      { 
+        "text": "Terms of use", 
+        "href": "/terms-of-use"
+      },
+      { 
+        "text": "System status", 
+        "href": "https://status.cloud.service.gov.uk/"
+      }
+    ]
+  } 
+}

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import data from './data.json'
+
+const navigation = data.navigation
+const meta = data.meta
+
+const Footer = () => (
+  <footer className="govuk-footer " role="contentinfo">
+    <div className="govuk-width-container ">
+     {navigation.length < 1 ? '' :
+        <div className="govuk-footer__navigation">
+          {navigation.map((column, index) => (
+            <div key={index} className="govuk-footer__section">
+              <h2 className="govuk-footer__heading govuk-heading-m">{column.title}</h2>
+                <ul className={`govuk-footer__list ${column.columns ? `govuk-footer__list--columns-${column.columns}` : ''}`}>
+                  {column.items.map((item) => (
+                    <li className="govuk-footer__list-item">
+                      <a className="govuk-footer__link" href={item.href}>
+                        {item.text}
+                      </a>
+                  </li>
+                  ))}
+                </ul>
+            </div>
+          ))}
+        </div>
+      }
+      <div className="govuk-footer__meta">
+        <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          {Object.keys(meta).length < 1 ? '' : <>
+            <h2 className="govuk-visually-hidden">{meta.visuallyHiddenTitle}</h2>
+            <ul className="govuk-footer__inline-list">
+              {meta.items.map((item, index) => (
+                <li key={index} className="govuk-footer__inline-list-item">
+                  <a className="govuk-footer__link" href={item.href}>
+                    {item.text}
+                  </a> 
+                </li>
+              ))}
+            </ul>
+          </>
+          }
+          <svg aria-hidden="true" focusable="false" className="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+          </svg>
+          <span className="govuk-footer__licence-description">
+            All content is available under the <a className="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
+        </div>
+        <div className="govuk-footer__meta-item">
+          <a className="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+        </div>
+    </div>
+  </div>
+  </footer>
+)
+
+export default Footer

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import Footer from '../components/Footer'
 
 class GovukTemplate extends Document {
   static async getInitialProps(ctx) {
@@ -10,11 +11,11 @@ class GovukTemplate extends Document {
     return (
       <Html lang='en' className='govuk-template'>
         <Head>
-          <meta charset="utf-8" />
+          <meta charSet="utf-8" />
           <title>GOV.UK Platform as a Service</title>
           <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
           <meta name="theme-color" content="#0b0c0c" />
-          <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
           <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon" />
           <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c" />
           <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png" />
@@ -47,7 +48,7 @@ class GovukTemplate extends Document {
               <Main />
             </main>
           </div>
-          {/* footer goes here */}
+          <Footer />
           <NextScript />
         </body>
       </Html>

--- a/styles/application.scss
+++ b/styles/application.scss
@@ -2,23 +2,28 @@ $govuk-global-styles: true;
 $govuk-assets-path: '/assets/';
 @import "govuk-frontend/govuk/all";
 
-h1 {
+// we only want to style content elements that don't have "govuk" classnames
+// so we don't affect component styles
+$notGOVUKClass: 'not([class^='govuk'])';
+
+h1:#{$notGOVUKClass} {
   @extend .govuk-heading-xl;
 }
 
-h2 {
+h2:#{$notGOVUKClass} {
   @extend .govuk-heading-l;
 }
 
-h3 {
+h3:#{$notGOVUKClass} {
   @extend .govuk-heading-m;
 }
 
-h4 {
+h4:#{$notGOVUKClass} {
   @extend .govuk-heading-s;
 }
 
-ol,ul {
+ol:#{$notGOVUKClass},
+ul:#{$notGOVUKClass} {
   @extend .govuk-list;
   @extend .govuk-list--bullet;
 }


### PR DESCRIPTION
## What
Create a site-wide footer component based on the [GOV.UK Design System component](https://design-system.service.gov.uk/components/footer/) but only with the "meta" section for now

The component utilises a JSON data file for it's links data.

PR also contains minor HTML markup fixes and updated stylesheet to avoid leaking element styles into components.

**Note: this component is lacking tests. [Here's an upcoming story to set up a testing framework](https://www.pivotaltracker.com/n/projects/1275640/stories/173075868)**

## Visual changes
### Before
<img width="983" alt="Screenshot 2020-05-28 at 15 02 57" src="https://user-images.githubusercontent.com/3758555/83151407-709ca580-a0f4-11ea-902e-c2cb6f39542e.png">

### After
<img width="994" alt="Screenshot 2020-05-28 at 15 00 58" src="https://user-images.githubusercontent.com/3758555/83151429-77c3b380-a0f4-11ea-81da-22b3ca415b58.png">

### How to review
- clone project
- optional: install node if you don't have it already
- install dependencies with `npm install`
- run `npm run dev` to build the app
- go to http://localhost:3000 to check the footer is looking as per https://design-system.service.gov.uk/components/footer#footer-with-links-to-meta-information (for now we're only using this variant
- review the code for any improvements