### PR TITLE
Create a Header component

### DIFF
--- a/components/Header/data.json
+++ b/components/Header/data.json
@@ -1,0 +1,30 @@
+{
+  "productName": "Platform as a Service",
+  "navigationClasses": "govuk-header__navigation--end",
+  "navigation": [
+    {
+      "href": "/get-started",
+      "text": "Get started"
+    },
+    {
+      "href": "/features",
+      "text": "Features"
+    },
+    {
+      "href": "/pricing",
+      "text": "Pricing"
+    },
+    {
+      "href": "https://docs.cloud.service.gov.uk/",
+      "text": "Documentation"
+    },
+    {
+      "href": "/support",
+      "text": "Support"
+    },
+    {
+      "href": "/sign-in",
+      "text": "Sign in"
+    }
+  ]
+}

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react'
+import data from './data.json'
+
+const Header = () => (
+<header className="govuk-header " role="banner" data-module="govuk-header">
+  <div className="govuk-header__container govuk-width-container">
+    <div className="govuk-header__logo">
+      <a href="/" className="govuk-header__link govuk-header__link--homepage">
+        <span className="govuk-header__logotype">
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            className="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 132 97"
+            height="30"
+            width="36"
+          >
+            <path
+              fill="currentColor" fillRule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+            <image
+              src="/assets/images/govuk-logotype-crown.png" 
+              xlinkHref="" 
+              className="govuk-header__logotype-crown-fallback-image" 
+              width="36" 
+              height="32">
+            </image>
+          </svg>{' '}
+          <span className="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+          {' '}
+        </span>
+        <span className="govuk-header__product-name">
+          {data.productName}
+        </span>
+      </a>
+    </div>
+    <div className="govuk-header__content">
+      {Object.keys(data.navigation).length < 1 ? '' : <>
+      <button type="button" className="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav>
+        <ul id="navigation" 
+          className={`govuk-header__navigation ${data.navigationClasses}`}
+          aria-label="Top Level Navigation"
+          >
+          {data.navigation.map((item, index) => (
+            <li key={index} className="govuk-header__navigation-item">
+              <a className="govuk-header__link" href={item.href}>
+                {item.text}
+              </a> 
+            </li>
+          ))}
+        </ul>
+      </nav>
+      </>}
+    </div>
+  </div>
+</header>
+)
+
+export default Header

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,12 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+
+interface IFallbackImage extends React.SVGProps<SVGImageElement> {
+  readonly src: string;
+}
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    readonly image: IFallbackImage;
+  }
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,5 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import Footer from '../components/Footer'
+import Header from '../components/Header'
 
 class GovukTemplate extends Document {
   static async getInitialProps(ctx) {
@@ -25,24 +26,8 @@ class GovukTemplate extends Document {
           <meta property="og:image" content="/assets/images/govuk-opengraph-image.png" />
         </Head>
         <body className="govuk-template__body">
-        <a href="#main-content" className="govuk-skip-link">Skip to main content</a>
-          <header className="govuk-header " role="banner" data-module="govuk-header">
-            <div className="govuk-header__container govuk-width-container">
-              <div className="govuk-header__logo">
-                <a href="/" className="govuk-header__link govuk-header__link--homepage">
-                  <span className="govuk-header__logotype">
-                    <svg aria-hidden="true" focusable="false" className="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-                      <path fill="currentColor" fillRule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-                      <image src="/assets/images/govuk-logotype-crown.png" className="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-                    </svg>
-                    <span className="govuk-header__logotype-text">
-                      GOV.UK
-                    </span>
-                  </span>
-                </a>
-              </div>
-            </div>
-          </header>
+          <a href="#main-content" className="govuk-skip-link">Skip to main content</a>
+          <Header />
           <div className="govuk-width-container">
             <main className="govuk-main-wrapper" id="main-content" role="main">
               <Main />

--- a/styles/application.scss
+++ b/styles/application.scss
@@ -1,6 +1,16 @@
 $govuk-global-styles: true;
 $govuk-assets-path: '/assets/';
+
+// values from GOV.UK Frontend with the added wide desktop breakpoint for the header navigation
+$govuk-breakpoints: (
+  mobile:  320px,
+  tablet:  641px,
+  desktop: 769px,
+  wideDesktop: 960px
+);
+
 @import "govuk-frontend/govuk/all";
+
 
 // we only want to style content elements that don't have "govuk" classnames
 // so we don't affect component styles
@@ -26,4 +36,28 @@ ol:#{$notGOVUKClass},
 ul:#{$notGOVUKClass} {
   @extend .govuk-list;
   @extend .govuk-list--bullet;
+}
+
+// PaaS spelled-out is a long name that GOV.UK Frontend doesn't account for
+// in the header logo + product name 33.33% width, so then name drops below the crown.
+//
+// To have the name always by the side of the crown and fit in the navaigation we need
+// to make styling tweaks below from tablet breakpoint and up
+
+@include govuk-media-query($from: tablet) {
+
+  .govuk-header__logo {
+    width: auto;
+  }
+
+  .govuk-header__content {
+    width: auto;
+    padding-left: 0;
+  }
+}
+
+@include govuk-media-query($from: wideDesktop) {
+  .govuk-header__content {
+    float: right;
+  }
 }


### PR DESCRIPTION
## What 
Create a site-wide header component based on the [GOV.UK Design System
component](https://design-system.service.gov.uk/components/header/)

The component utilises a JSON data file for product name and navigation
links.

We'll set up, bundle and initialise govuk-frontend javascript in a separate ticket

**Note: this component is lacking tests. There's an upcoming story to set
up a testing framework.**

This PR also contains 
- style tweaks for the header to allow for the long PaaS name 
- an extension of the `SVGImage` element to allow for src attribute on the `<image>` child element which GOV.UK Frontend uses to provide a fallback crown logo for IE8.

## Visual changes

### Before
<img width="990" alt="Screenshot 2020-06-03 at 07 24 04" src="https://user-images.githubusercontent.com/3758555/83602848-3f482d80-a56b-11ea-85df-18820068c6bd.png">

### After
<img width="991" alt="Screenshot 2020-06-03 at 07 23 33" src="https://user-images.githubusercontent.com/3758555/83602864-47a06880-a56b-11ea-82d0-21fe29bbb3c5.png">


## How to review
- clone project
- checkout the `header-component` branch
- optional: install node if you don't have it already
- install dependencies with `npm install`
- run `npm run dev` to build the app
- go to `http://localhost:3000` to check the header is looking as per https://design-system.service.gov.uk/components/header
- review the code for any improvements