### PR TITLE
Create a custom 404 page

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,22 @@
+export default function Custom404() {
+  return (
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Page not found</h1>
+        <p class="govuk-body">Sorry the page you requested was not found.</p>
+        <p class="govuk-body">
+          If you typed the web address, check it is correct.
+        </p>
+        <p class="govuk-body">
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p class="govuk-body">Alternatively, try one of these:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="/">The GOV.UK PaaS home page</a></li>
+          <li><a href="/get-started">Getting Started</a></li>
+          <li><a href="/features">Features</a></li>
+        </ul>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What 
Replace the NextJS default 404 page with a pattern from
[GOV.UK Design system](https://design-system.service.gov.uk/patterns/page-not-found-pages/) as per [NextJS docs](https://nextjs.org/docs/advanced-features/custom-error-page)

Content was adapted from the existing 404 page: https://www.cloud.service.gov.uk/bb

Note: When #5 get's merged in, header will look better :)

## Visual changes

### Before
<img width="1011" alt="Screenshot 2020-06-03 at 07 43 19" src="https://user-images.githubusercontent.com/3758555/83604442-14aba400-a56e-11ea-8f93-e0961186d585.png">

### After
<img width="1033" alt="Screenshot 2020-06-03 at 07 43 00" src="https://user-images.githubusercontent.com/3758555/83604465-1b3a1b80-a56e-11ea-8fee-1cd08b5de3aa.png">

## How to review
- clone project
- checkout the `404-page` branch
- optional: install node if you don't have it already
- install dependencies with `npm install`
- run `npm run dev` to build the app
- go to `http://localhost:3000/whatever` to check the page is looking as per https://design-system.service.gov.uk/patterns/page-not-found-pages/
- review the code for any improvements
