### PR TITLE
Create a Page-with-sidenav layout

### DIFF
--- a/layouts/PagewithSideNav.tsx
+++ b/layouts/PagewithSideNav.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const PageWithSideNav = ({ children }) => (
+  <div className="govuk-grid-row">
+    <div className="govuk-grid-column-one-third">
+      <p>navigation goes here</p>
+    </div>
+    <div className="govuk-grid-column-two-thirds">
+      {children}
+    </div>
+  </div>
+)
+
+export default PageWithSideNav 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
-import Footer from '../components/Footer'
-import Header from '../components/Header'
+import Footer from '@components/Footer'
+import Header from '@components/Header'
 
 class GovukTemplate extends Document {
   static async getInitialProps(ctx) {

--- a/pages/get-started/index.mdx
+++ b/pages/get-started/index.mdx
@@ -1,3 +1,7 @@
+import PageWithSideNav from '@layouts/PageWithSideNav'
+
+<PageWithSideNav>
+
 # Get started with GOV.UK PaaS
 
 ## Evaluate GOV.UK PaaS
@@ -45,3 +49,5 @@ Once your department has signed an MOU, you will need to:
 
 -   [add a Billing Manager to your GOV.UK PaaS organisation](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles), who can authorise and manage payment for the service
 -   email [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request the upgrade, copying in your Billing Manager
+
+</PageWithSideNav>

--- a/pages/get-started/index.mdx
+++ b/pages/get-started/index.mdx
@@ -1,0 +1,47 @@
+# Get started with GOV.UK PaaS
+
+## Evaluate GOV.UK PaaS
+
+### Check our features and pricing
+
+Make sure we currently support the [language, framework and backing services](/features) you need. Our [roadmap](/roadmap) lists the features planned for release in the coming months.
+
+You can also find out [how our pricing works](/pricing) and [estimate your monthly costs](https://admin.london.cloud.service.gov.uk/calculator).
+
+If you need more information to support your evaluation, please [get in contact with us](/support/find-out-more).
+
+### Request a free trial account
+
+GOV.UK PaaS offers a 3 month trial period with a set of basic features and a capped quota of compute and storage.
+
+During this period you can test the majority of the features, including:
+
+-   managing user accounts
+-   creating and managing environments
+-   deploying and running apps
+-   using trial-sized editions of our backing services
+
+Keep in mind that you can't use the trial version of the platform for production or live services.
+
+[Contact us to request an account](/signup).
+
+When you request an account you can invite as many team members as you need and choose the ones who'll be in charge of managing users. Theyâ€™ll be able to request more user accounts, including ones for external suppliers, and assign [roles and permissions](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles).
+
+### Push your first app
+
+Once we set up your account and you have [installed the Cloud Foundry CLI](https://docs.cloud.service.gov.uk/get_started.html#set-up-command-line), you can access GOV.UK PaaS, set a password and start using the platform straight away. Our [get started](https://docs.cloud.service.gov.uk/get_started.html#get-started) guide will help you deploy a static site to test your connection and then [push some sample code](https://docs.cloud.service.gov.uk/deploying_apps.html#deploying-apps), use the marketplace to [request backing services like databases](https://docs.cloud.service.gov.uk/deploying_services/), and set up multiple environments and a development pipeline.
+
+### Support during your trial
+
+Check the documentation to [troubleshoot common problems](https://docs.cloud.service.gov.uk/troubleshooting.html#troubleshooting). If you can't find a solution our team can help during office hours. Contact us through our [support page](/support).
+
+## Start using a paid quota
+
+To access full platform features or to use GOV.UK PaaS for production or live services, you will need to be on a paid quota.
+
+To start using a paid quota, your organisation will need to sign a Crown or non-Crown Memorandum of Understanding (MOU) with Government Digital Service, depending on the type of organisation the service belongs to. Contact us to find out if your organisation has signed an MOU, or to get a copy.
+
+Once your department has signed an MOU, you will need to:
+
+-   [add a Billing Manager to your GOV.UK PaaS organisation](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles), who can authorise and manage payment for the service
+-   email [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request the upgrade, copying in your Billing Manager

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,12 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@layouts/*": ["layouts/*"]
+    }
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## What
For pages in sections, we need a layout that has room for section side navigation.

This layout will be parsed by MDX if specified as a layout for each page and render the proper HTML markup
Example of existing page layout: https://www.cloud.service.gov.uk/get-started

## Visual changes

### Before
<img width="998" alt="Screenshot 2020-06-03 at 09 10 22" src="https://user-images.githubusercontent.com/3758555/83614052-930f4280-a57c-11ea-80cd-3fb0e5280f90.png">

### After
<img width="991" alt="Screenshot 2020-06-03 at 09 11 58" src="https://user-images.githubusercontent.com/3758555/83614077-9b677d80-a57c-11ea-90fa-8cb7bae20210.png">

## How to review
- clone project
- checkout the `page-with-sidenav-layout` branch
- optional: install node if you don't have it already
- install dependencies with `npm install`
- run `npm run dev` to build the app
- go to `http://localhost:3000//get-started` to check the page content is in a 2/3 grid layout
- review the code for any improvements
