### PR TITLE
Fix 404 page

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,22 +1,25 @@
+import GenericLayout from '@layouts/GenericLayout'
 export default function Custom404() {
   return (
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Page not found</h1>
-        <p class="govuk-body">Sorry the page you requested was not found.</p>
-        <p class="govuk-body">
+    <GenericLayout>
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">
+        <h1 className="govuk-heading-l">Page not found</h1>
+        <p className="govuk-body">Sorry the page you requested was not found.</p>
+        <p className="govuk-body">
           If you typed the web address, check it is correct.
         </p>
-        <p class="govuk-body">
+        <p className="govuk-body">
           If you pasted the web address, check you copied the entire address.
         </p>
-        <p class="govuk-body">Alternatively, try one of these:</p>
-        <ul class="govuk-list govuk-list--bullet">
+        <p className="govuk-body">Alternatively, try one of these:</p>
+        <ul className="govuk-list govuk-list--bullet">
           <li><a href="/">The GOV.UK PaaS home page</a></li>
           <li><a href="/get-started">Getting Started</a></li>
           <li><a href="/features">Features</a></li>
         </ul>
       </div>
     </div>
+    </GenericLayout>
   )
 }


### PR DESCRIPTION
Wrap in generic layout and replace `class` with `className` to remove errors