### PR TITLE
Heading anchor links

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,16 @@
 const withMdxEnhanced = require('next-mdx-enhanced')
+const rehypeSlug = require('rehype-slug')
+const rehypeAutolinkHeadings = require('rehype-autolink-headings')
 
 module.exports = withMdxEnhanced({
   layoutPath: 'layouts/Content/',
   defaultLayout: true,
   fileExtensions: ['mdx'],
   remarkPlugins: [],
-  rehypePlugins: [],
+  rehypePlugins: [
+    rehypeSlug,
+    rehypeAutolinkHeadings
+  ],
   extendFrontMatter: {
     process: (mdxContent, frontMatter) => {},
     phase: 'prebuild|loader|both',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4635,6 +4635,11 @@
         }
       }
     },
+    "emoji-regex": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+    },
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -5202,6 +5207,14 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
+    "github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -5403,6 +5416,16 @@
         "xtend": "^4.0.1"
       }
     },
+    "hast-util-has-property": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
+      "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg=="
+    },
+    "hast-util-is-element": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz",
+      "integrity": "sha512-NFR6ljJRvDcyPP5SbV7MyPBgF47X3BsskLnmw1U34yL+X6YC0MoBx9EyMg8Jtx4FzGH95jw8+c1VPLHaRA0wDQ=="
+    },
     "hast-util-parse-selector": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
@@ -5434,6 +5457,11 @@
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
       }
+    },
+    "hast-util-to-string": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.3.tgz",
+      "integrity": "sha512-3lDgDE5OdpTfP3aFeKRWEwdIZ4vprztvp+AoD+RhF7uGOBs1yBDWZFadxnjcUV4KCoI3vB9A7gdFO98hEXA90w=="
     },
     "hastscript": {
       "version": "5.1.2",
@@ -7655,6 +7683,29 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
+      }
+    },
+    "rehype-autolink-headings": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-3.0.0.tgz",
+      "integrity": "sha512-Kit6caYCGvH7OSeXgEq0F4b4vXFg92owru/26ckSLCODjvbD4TogAOvYvzcvkaeIO0uDpnmCg0MsmHJtHXBvyQ==",
+      "requires": {
+        "extend": "^3.0.1",
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-is-element": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "rehype-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-3.0.0.tgz",
+      "integrity": "sha512-zFnj5BCEJXV6+URwaz8yW+9BdjDwO5iVzlQui3+7cCJ9MXlIEL0IY8VefcT/03Gw+2Hutdrx+zXnS7bnOrepZg==",
+      "requires": {
+        "github-slugger": "^1.1.1",
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-is-element": "^1.0.0",
+        "hast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
       }
     },
     "remark-footnotes": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "next-mdx-enhanced": "^3.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "rehype-autolink-headings": "^3.0.0",
+    "rehype-slug": "^3.0.0",
     "sass": "^1.26.5"
   },
   "license": "MIT",

--- a/styles/application.scss
+++ b/styles/application.scss
@@ -78,3 +78,42 @@ img {
     float: right;
   }
 }
+
+
+// heading anchor link styles
+h2,
+h3,
+h4 {
+  position: relative;
+}
+
+h2 > a,
+h3 > a,
+h4 > a  {
+  position: absolute;
+  display: none;
+  left: -.75em;
+  width: .75em;
+
+  &:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: $govuk-focus-colour;
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-text-colour;
+    text-decoration: none;
+  }
+  .icon-link {
+    width: 16px;
+    height: 16px;
+  }
+  .icon-link:after {
+    content: '#';
+    color: $govuk-text-colour;
+  }
+}
+
+h2:hover > a,
+h3:hover > a,
+h4:hover > a  {
+  display: block;
+}


### PR DESCRIPTION
MDX already uses remark and rehype to turn markdown into HTML,
so this to plugins naturally fit in and apply IDs and anchor links to headings.

<img width="508" alt="Screenshot 2020-06-10 at 10 42 39" src="https://user-images.githubusercontent.com/3758555/84252935-2dd0c980-ab07-11ea-8ca0-299ea450ae93.png">
