### PR TITLE
Remove cookies page link in the footer

### DIFF
--- a/components/Footer/data.json
+++ b/components/Footer/data.json
@@ -8,10 +8,6 @@
         "href": "https://www.gov.uk/government/organisations/government-digital-service"
       },
       { 
-        "text": "Cookies", 
-        "href": "/cookies"
-      },
-      { 
         "text": "Privacy notice", 
         "href": "/privacy-notice"
       },


### PR DESCRIPTION
We currently don't store any cookies