### PR TITLE
Update the config to maximise caching

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,11 +37,13 @@ http {
     text/html                       epoch;
     text/css                        max;
     application/javascript          max;
+    application/x-javascript        max;
     application/json                max;
     ~application/x-font             max;
     ~application/font               max;
     application/vnd.ms-fontobject   max;
-    ~image/                         30m;
+    ~image/                         max;
+    image/x-icon                    max;
     ~video/                         30m;
   }
 
@@ -55,7 +57,7 @@ http {
     location / {
       index index.html index.htm;
       error_page 404 /404/index.html;
-      add_header Cache-Control "public";
+      add_header Cache-Control "public, immutable";
       expires $expires;
     }
   }


### PR DESCRIPTION
Updated a few settings to maximise caching:

- JS was being served as `application/x-javascript`, so this has been added (alternative: serve everything as application/javascript)
- images upped to max time to follow expectations set by [Lighthouse](https://web.dev/uses-long-cache-ttl/#how-to-cache-static-resources-using-http-caching)
- add `immutable` to the static files following guidance on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Caching_static_assets)