### PR TITLE
Small tweak to the mimetypes being sent and the caching applied

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,8 @@ http {
     text/css                        max;
     application/javascript          max;
     application/json                max;
+    font/woff                       max;
+    font/woff2                      max;
     ~application/x-font             max;
     ~application/font               max;
     application/vnd.ms-fontobject   max;

--- a/nginx.conf
+++ b/nginx.conf
@@ -37,7 +37,6 @@ http {
     text/html                       epoch;
     text/css                        max;
     application/javascript          max;
-    application/x-javascript        max;
     application/json                max;
     ~application/x-font             max;
     ~application/font               max;

--- a/nginx/mime.types
+++ b/nginx/mime.types
@@ -4,7 +4,7 @@ types {
   text/xml xml;
   image/gif gif;
   image/jpeg jpeg jpg;
-  application/x-javascript js;
+  application/javascript js;
   application/atom+xml atom;
   application/rss+xml rss;
   font/ttf ttf;
@@ -60,8 +60,6 @@ types {
   application/octet-stream msi msp msm;
   application/x-font-ttf ttc ttf;
   application/x-font-otf otf;
-  application/font-woff woff;
-  application/font-woff2 woff2;
   application/vnd.ms-fontobject eot;
   application/json json;
   audio/midi mid midi kar;


### PR DESCRIPTION
Very small tweak to the setup. 

- Removed duplicate woff/woff2 reference in mime.types, so now using `font/woff`, `font/woff2`
- JS now being served as `application/javascript` as mentioned in [RFC 4329](http://www.rfc-editor.org/rfc/rfc4329.txt)