### PR TITLE
Add a sign in page

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -61,5 +61,14 @@ http {
       add_header Cache-Control "public, immutable";
       expires $expires;
     }
+
+    location /sign-in {
+      if ($args ~ '\bregion=london' ) {
+        return 302 https://login.london.cloud.service.gov.uk;
+      }
+      if ($args ~ '\bregion=ireland' ) {
+        return 302 https://login.cloud.service.gov.uk;
+      }
+    }
   }
 }

--- a/pages/sign-in.mdx
+++ b/pages/sign-in.mdx
@@ -1,0 +1,41 @@
+---
+title: "Sign in to GOV.UK PaaS"
+---
+import Button from '@components/Button'
+
+<form>
+  <div className="govuk-form-group">
+    <fieldset className="govuk-fieldset">
+      <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h2 className="govuk-fieldset__heading">
+          Choose your region
+        </h2>
+      </legend>
+      <div className="govuk-radios">
+        <div className="govuk-radios__item">
+          <input className="govuk-radios__input" id="region-london" name="region" type="radio" value="london" aria-describedby="region-london-hint" />
+          <label className="govuk-label govuk-radios__label govuk-label--s" htmlFor="region">
+            London
+          </label>
+          <span id="region-london-hint" className="govuk-hint govuk-radios__hint">
+            Apps without a custom domain end with <code>london.cloudapps.digital</code>.
+          </span>
+        </div>
+        <div className="govuk-radios__item">
+          <input className="govuk-radios__input" id="region-ireland" name="region" type="radio" value="ireland" aria-describedby="region-ireland-hint" />
+          <label className="govuk-label govuk-radios__label govuk-label--s" htmlFor="region-ireland">
+            Ireland
+          </label>
+          <span id="region-ireland-item-hint" className="govuk-hint govuk-radios__hint">
+            Apps without a custom domain end with <code>cloudapps.digital</code>.
+          </span>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <Button element="input">Continue</Button>
+</form>
+
+## Use the Command Line
+
+If you need help accessing GOV.UK PaaS from the command-line interface, take a look at our [technical documentation](https://docs.cloud.service.gov.uk/get_started.html#set-up-the-cloud-foundry-command-line).

--- a/styles/application.scss
+++ b/styles/application.scss
@@ -18,6 +18,7 @@ $govuk-breakpoints: (
 @import "node_modules/govuk-frontend/govuk/components/footer/index";
 @import "node_modules/govuk-frontend/govuk/components/header/index";
 @import "node_modules/govuk-frontend/govuk/components/inset-text/index";
+@import "node_modules/govuk-frontend/govuk/components/radios/index";
 @import "node_modules/govuk-frontend/govuk/components/skip-link/index";
 @import "node_modules/govuk-frontend/govuk/components/table/index";
 @import "node_modules/govuk-frontend/govuk/utilities/all";


### PR DESCRIPTION
Add a sign-in page where users select which region they'd like to sign into PaaS admin in.
Form uses HTML from the Design system directly.

Massive help by @tlwr on this, writing the nginx solution

[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/173330663)