### PR TITLE
Move section nav out of main element

### DIFF
--- a/layouts/Content/index.tsx
+++ b/layouts/Content/index.tsx
@@ -16,22 +16,36 @@ export default function contentPage(frontMatter) {
           }
         </title>
       </Head>
-      <div className="govuk-width-container">
-        <main className="govuk-main-wrapper" id="main-content" role="main">
-          <GridRow>
-            { frontMatter.sectionNav ? ( 
-            <GridColumn width='one-third'>
-              <SectionNavigation section={frontMatter.section} />
-            </GridColumn> ) : <></>
-            }
-            <GridColumn width='two-thirds'>
-              {frontMatter && frontMatter.title ? (
-                <h1 className="govuk-heading-xl">{frontMatter.title}</h1>
-              ): <></>}
-              {content}
-            </GridColumn>
-          </GridRow>
-        </main>
+      <div className="govuk-width-container ">
+        { frontMatter.sectionNav ? (
+            <>
+            <GridRow>
+              <GridColumn width='one-third'>
+                <SectionNavigation section={frontMatter.section} />
+              </GridColumn>
+              <GridColumn width='two-thirds'>
+                <main className="govuk-main-wrapper" id="main-content" role="main">
+                  {frontMatter && frontMatter.title ? (
+                      <h1 className="govuk-heading-xl">{frontMatter.title}</h1>
+                    ): <></>}
+                  {content}
+                </main>
+              </GridColumn>
+            </GridRow>
+            </>
+          ) : (
+            <main className="govuk-main-wrapper" id="main-content" role="main">
+            <GridRow>
+              <GridColumn width='two-thirds'>
+                {frontMatter && frontMatter.title ? (
+                  <h1 className="govuk-heading-xl">{frontMatter.title}</h1>
+                ): <></>}
+                {content}
+              </GridColumn>
+            </GridRow>
+          </main>
+          )
+        }
       </div>
       </>
     )

--- a/styles/_section-navigation.scss
+++ b/styles/_section-navigation.scss
@@ -1,5 +1,11 @@
 .section-navigation {
-  margin-bottom: govuk-spacing(6);
+  padding-top: govuk-spacing(4);
+  padding-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(7);
+    padding-bottom: govuk-spacing(7);
+  }
 
   ol,
   ul {


### PR DESCRIPTION
Users use the skip link to skip to content, at the moment they have to tab through the
section navigation to get to the main content.

This moves the navigation outside the main element and adjusts the spacing