### PR TITLE
Add redirect for /support

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -70,5 +70,9 @@ http {
         return 302 https://login.cloud.service.gov.uk;
       }
     }
+
+    location /support {
+      return 302 https://admin.london.cloud.service.gov.uk/support;
+    }
   }
 }


### PR DESCRIPTION
## What
Add  redirect for `cloud.service.gov.uk/support` to redirects to `https://admin.london.cloud.service.gov.uk/support`

Requested by Mr. Duggan: "as a tech arch I spend a lot of time pointing people to things either via slack, hangouts, docs, sheets, slides and having easily memorable permalinks helps when in meetings"

## How to review
- install docker
- checkout branch
- run `npm install`
- run `npm run build`
- run `npm run nginx:local`
- visit `http://localhost:8080/support` to be redirected to  `https://admin.london.cloud.service.gov.uk/support`

