### PR TITLE
Bump govuk-frontend and audit npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5563,9 +5563,9 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "govuk-frontend": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
-      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.8.0.tgz",
+      "integrity": "sha512-+vgXzFsh7wpLRGjFSDvDcA2zNA2wOxT6gGs/KUpkTjF1Uop9BerW/1W/YB1BMpeTEJoPlmrkA19+DS1fqJtL9Q=="
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -6373,9 +6373,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@mdx-js/loader": "^1.5.1",
     "@next/mdx": "^9.1.1",
     "babel-plugin-import-glob-array": "^0.2.0",
-    "govuk-frontend": "^3.7.0",
+    "govuk-frontend": "^3.8.0",
     "next": "latest",
     "next-mdx-enhanced": "^3.0.0",
     "postcss-nested": "^4.2.1",


### PR DESCRIPTION
- [Changelog for govuk-frontend v3.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.8.0)

- npm audit log

```
found 451 low severity vulnerabilities in 1329 scanned packages
  run `npm audit fix` to fix 451 of them.
paas-product-pages % npm audit fix
npm WARN paas-product-pages@1.0.0 No repository field.

updated 1 package in 6.733s

100 packages are looking for funding
  run `npm fund` for details

fixed 451 of 451 vulnerabilities in 1329 scanned packages
paas-product-pages % npm audit

=== npm audit security report===

found 0 vulnerabilities
 in 1329 scanned packages
```