### PR TITLE
Pre-select sign-in region radio option

### DIFF
--- a/pages/sign-in.mdx
+++ b/pages/sign-in.mdx
@@ -13,7 +13,7 @@ import Button from '@components/Button'
       </legend>
       <div className="govuk-radios">
         <div className="govuk-radios__item">
-          <input className="govuk-radios__input" id="region-london" name="region" type="radio" value="london" aria-describedby="region-london-hint" />
+          <input className="govuk-radios__input" id="region-london" name="region" type="radio" value="london" defaultChecked={true} aria-describedby="region-london-hint" />
           <label className="govuk-label govuk-radios__label govuk-label--s" htmlFor="region-london">
             London
           </label>


### PR DESCRIPTION
DAC audit raised an issue that there was no error when users hit
continue without selecting an option.

As these are static pages, we don/t have a way to check if an option
was selected to throw an error.

That's why we're pre-selecting the first option.