### PR TITLE
Fix broken things

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -71,7 +71,7 @@ http {
       }
     }
 
-    location /support {
+    location = /support {
       return 302 https://admin.london.cloud.service.gov.uk/support;
     }
   }

--- a/pages/cloud-security-principles.mdx
+++ b/pages/cloud-security-principles.mdx
@@ -27,7 +27,7 @@ GOV.UK PaaS runs in AWS data centres in the London and Dublin regions. As GOV.UK
 
 By default all backing services created through GOV.UK PaaS are encrypted at rest, it is not possible to disable at rest encryption.
 
-GOV.UK PaaS is 99.99% available and we publish the [availability of the components that make up the platform](https://status.cloud.service.gov.uk/) as well as previous incident reports. GOV.UK PaaS has a published [support and response time](/support-and-resolution-times) for each category of incident that may affect applications running on GOV.UK PaaS.
+GOV.UK PaaS is 99.99% available and we publish the [availability of the components that make up the platform](https://status.cloud.service.gov.uk/) as well as previous incident reports. GOV.UK PaaS has a published [support and response time](/support-and-response-times) for each category of incident that may affect applications running on GOV.UK PaaS.
 
 ## 3\. Separation between users
 

--- a/pages/features.mdx
+++ b/pages/features.mdx
@@ -82,4 +82,4 @@ We monitor the infrastructure and manage the patching of the platform's operatin
 
 We offer 24/7 platform support for live services
 
-[Read about the support we offer](//support-and-resolution-times)
+[Read about the support we offer](/support-and-response-times#response-times-for-services-in-production)

--- a/pages/pricing.mdx
+++ b/pages/pricing.mdx
@@ -20,7 +20,7 @@ The price we charge includes a 10% service fee to cover the internal overhead of
 included in this price are:
 
 -   as many [users or organisations](https://docs.cloud.service.gov.uk/orgs_spaces_users.html) as you need
--   access to our all our [support channels](/support-and-resolution-times), including 24/7 support for live services
+-   access to our all our [support channels](/support-and-response-times), including 24/7 support for live services
 -   a user friendly administration tool for managing your organisations, users, applications and billing
 -   full access to all the [features of the platform](/features)
 


### PR DESCRIPTION
## What

- correctly link to the /support-and-response-times page
- fix url redirect, so that ` /support-and-response-times` doesn't get redirect necessarily