### PR TITLE
Associate homepage page title and heading

### DIFF
--- a/components/MastHead/index.tsx
+++ b/components/MastHead/index.tsx
@@ -16,7 +16,7 @@ const Masthead = () => {
         </div>
         <div className="govuk-grid-row">
           <div className="masthead__body govuk-grid-column-two-thirds">
-            <h1 className="govuk-heading-xl masthead__title ">Host your service in the Cloud</h1>
+            <h1 className="govuk-heading-xl masthead__title ">Host your service in the Cloud< span className="govuk-visually-hidden">with GOV.UK Platform as a service (PaaS)</span></h1>
             <div className="masthead__inline-image">
               <img src="/assets/images/paas-top-image.png" alt="" role="presentation" />
             </div>

--- a/layouts/Content/Homepage.tsx
+++ b/layouts/Content/Homepage.tsx
@@ -8,7 +8,7 @@ export default function HomePage() {
     return (
       <>
       <Head>
-        <title>{config.siteName}</title>
+        <title>{`Host your service in the Cloud - ${config.siteName}`}</title>
       </Head>
       <main id="main-content" role="main">
         <div className="app-width-container">


### PR DESCRIPTION
Adjust title and main heading to create association for screenreader
users. This is a usability issue, not a WCAG issue

“The page title was reported by JAWS as ‘GOV.UK Platform as a Service’.
However, the level 1 heading on the homepage is ‘Host your service in
the cloud’. This is confusing because it is unclear as to what the page
refers. When combined, page titles and level 1 headings describe the
purpose and function of a page and its content. I would therefore expect
he page title and level 1 heading to match.”

Ticket: https://www.pivotaltracker.com/n/projects/1275640/stories/174314818