### PR TITLE
Move homepage breadcrumb out of main element

### DIFF
--- a/components/MastHead/index.tsx
+++ b/components/MastHead/index.tsx
@@ -6,14 +6,6 @@ const Masthead = () => {
   return (
     <div className="masthead">
       <div className="masthead__content">
-        <div className="govuk-breadcrumbs masthead__breadcrumbs">
-          <ol className="govuk-breadcrumbs__list">
-            <li className="govuk-breadcrumbs__list-item">
-              <a className="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
-            </li>
-            <li className="govuk-breadcrumbs__list-item" aria-current="page">GOV.UK PaaS</li>
-          </ol>
-        </div>
         <div className="govuk-grid-row">
           <div className="masthead__body govuk-grid-column-two-thirds">
             <h1 className="govuk-heading-xl masthead__title ">Host your service in the Cloud< span className="govuk-visually-hidden">with GOV.UK Platform as a service (PaaS)</span></h1>

--- a/layouts/Content/Homepage.tsx
+++ b/layouts/Content/Homepage.tsx
@@ -10,6 +10,16 @@ export default function HomePage() {
       <Head>
         <title>{`Host your service in the Cloud - ${config.siteName}`}</title>
       </Head>
+      <div className="app-width-container">
+        <div className="govuk-breadcrumbs app-breadcrumbs app-breadcrumbs--inverse">
+          <ol className="govuk-breadcrumbs__list">
+            <li className="govuk-breadcrumbs__list-item">
+              <a className="govuk-breadcrumbs__link" href="https://www.gov.uk/service-toolkit#gov-uk-services">GOV.UK services</a>
+            </li>
+            <li className="govuk-breadcrumbs__list-item" aria-current="page">GOV.UK PaaS</li>
+          </ol>
+        </div>
+      </div>
       <main id="main-content" role="main">
         <div className="app-width-container">
           <Masthead />

--- a/styles/_masthead.scss
+++ b/styles/_masthead.scss
@@ -1,10 +1,9 @@
 .masthead {
   background-color: $govuk-brand-colour;
-  margin-top: -11px;
 }
 .masthead__content {
   @extend .govuk-width-container;
-  padding-top: govuk-spacing(2);
+  padding-top: govuk-spacing(5);
 }
 
 .masthead__title {
@@ -42,37 +41,6 @@
   img {
     max-width: 100%;
     margin-top: govuk-spacing(3);
-  }
-}
-.masthead__breadcrumbs {
-  color: govuk-colour('white');
-  border-bottom: 1px solid rgba(govuk-colour("white"), .25);
-  padding-bottom: govuk-spacing(2);
-  margin-top: 0;
-  margin-bottom: govuk-spacing(5);
-
-  .govuk-breadcrumbs__list-item{
-    &:before {
-      border-color: govuk-colour('white');
-    }
-
-    &[aria-current=page]{
-      font-weight: 700;
-      color: govuk-colour('white');
-    }
-  }
-
-  .govuk-breadcrumbs__link {
-    color: govuk-colour('white');
-
-    &:hover,
-    &:active {
-      color: govuk-colour('white');
-    }
-
-    &:focus {
-      color:  $govuk-text-colour;
-    }
   }
 }
 

--- a/styles/application.scss
+++ b/styles/application.scss
@@ -152,3 +152,41 @@ blockquote {
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
 }
+
+//homepage breadcrumb -- inverse
+.app-breadcrumbs--inverse {
+  background-color: $govuk-brand-colour;
+  color: govuk-colour('white');
+  border-bottom: 1px solid rgba(govuk-colour("white"), .25);
+  padding-bottom: govuk-spacing(2);
+  margin-top: -11px;
+  padding-top: govuk-spacing(2);
+  margin-bottom: 0;
+
+  .govuk-breadcrumbs__list {
+    @extend .govuk-width-container;
+  }
+  .govuk-breadcrumbs__list-item{
+    &:before {
+      border-color: govuk-colour('white');
+    }
+
+    &[aria-current=page]{
+      font-weight: 700;
+      color: govuk-colour('white');
+    }
+  }
+
+  .govuk-breadcrumbs__link {
+    color: govuk-colour('white');
+
+    &:hover,
+    &:active {
+      color: govuk-colour('white');
+    }
+
+    &:focus {
+      color:  $govuk-text-colour;
+    }
+  }
+}


### PR DESCRIPTION
## What 

Having breadcrumbs inside main element cause the skipLink to fail to focus correctly.

Issue is very evident in IE11, where focus goes back to the skipLink

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174315267

No visual changes.

## How to review
- checkout branch
- run `npm run local`
- go to localhost:3000 and compare homepage against live
- use Tab key to get to Skip Link. Press ENTER, then Tab again.
- Focus should now be on the "How to get started" button