### PR TITLE
Generate page contents list

### DIFF
--- a/lib/rehype-removeTOC.js
+++ b/lib/rehype-removeTOC.js
@@ -1,0 +1,23 @@
+const visit = require('unist-util-visit')
+const remove = require('unist-util-remove')
+
+module.exports = removeTocFromCertainPages
+
+function removeTocFromCertainPages() {
+  return removeTOC
+}
+
+function removeTOC(tree) {
+  let pageDetails = tree.children.find(o => o.default === true);
+  let isHomePage = pageDetails.value.includes("layout: 'Homepage'");
+  let isSignInPage = pageDetails.value.includes("__resourcePath: 'sign-in.mdx'");
+  let is404Page = pageDetails.value.includes("__resourcePath: '404.mdx'");
+  let cookiesPage = pageDetails.value.includes("__resourcePath: 'cookies.mdx'");
+  if (isHomePage || isSignInPage || is404Page || cookiesPage) {
+    visit(tree, 'element', function (node) {
+      if (node.tagName === 'nav') {
+          remove(tree, node)
+      }
+    })
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 const withMdxEnhanced = require('next-mdx-enhanced')
 const rehypeSlug = require('rehype-slug')
-const rehypeAutolinkHeadings = require('rehype-autolink-headings')
+const toc = require("@jsdevtools/rehype-toc");
+const removeTOC = require("./lib/rehype-removeTOC");
 
 module.exports = withMdxEnhanced({
   layoutPath: 'layouts/Content/',
@@ -9,7 +10,39 @@ module.exports = withMdxEnhanced({
   remarkPlugins: [],
   rehypePlugins: [
     rehypeSlug,
-    rehypeAutolinkHeadings
+    [toc,{
+      headings: ["h2", "h3", "h4"],  
+      cssClasses: {
+        toc: "app-toc",
+        list: "app-toc__list",
+        listItem: "app-toc__list-item",
+        link: "app-toc__link",
+      },
+      customizeTOC: function(toc) {
+        if (toc.type === 'element' && toc.tagName === 'nav') {
+          toc.properties.role = 'navigation';
+        }
+        if (toc.children[0].children.length === 0) {
+          return false
+        } else {
+          toc.children.unshift({
+            type: 'element',
+            tagName: 'h2',
+            children: [
+              {
+                "type": "text",
+                "value": "Contents"
+              }
+            ],
+            properties: {
+              className: 'app-toc__heading'
+            }
+          })
+          return toc
+        }
+      }
+    }],
+    removeTOC
   ],
   extendFrontMatter: {
     process: (mdxContent, frontMatter) => {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2899,6 +2899,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@jsdevtools/rehype-toc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/rehype-toc/-/rehype-toc-3.0.2.tgz",
+      "integrity": "sha512-n5JEf16Wr4mdkRMZ8wMP/wN9/sHmTjRPbouXjJH371mZ2LEGDl72t8tEsMRNFerQN/QJtivOxqK1frdGa4QK5Q=="
+    },
     "@mdx-js/loader": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.1.tgz",
@@ -9188,17 +9193,6 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
-      }
-    },
-    "rehype-autolink-headings": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-3.0.0.tgz",
-      "integrity": "sha512-Kit6caYCGvH7OSeXgEq0F4b4vXFg92owru/26ckSLCODjvbD4TogAOvYvzcvkaeIO0uDpnmCg0MsmHJtHXBvyQ==",
-      "requires": {
-        "extend": "^3.0.1",
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "unist-util-visit": "^2.0.0"
       }
     },
     "rehype-slug": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "nginx:local": "docker run --rm -it -v $PWD:/etc/nginx -p 8080:8080 nginx bash -c 'cp /etc/nginx/nginx.conf /tmp/nginx.old && sed -i 's/{{port}}/8080/' /etc/nginx/nginx.conf && nginx ; mv /tmp/nginx.old /etc/nginx/nginx.conf'"
   },
   "dependencies": {
+    "@jsdevtools/rehype-toc": "^3.0.2",
     "@mdx-js/loader": "^1.5.1",
     "@next/mdx": "^9.1.1",
     "babel-plugin-import-glob-array": "^0.2.0",
@@ -21,9 +22,9 @@
     "postcss-nested": "^4.2.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "rehype-autolink-headings": "^3.0.0",
     "rehype-slug": "^3.0.0",
-    "sass": "^1.26.5"
+    "sass": "^1.26.5",
+    "unist-util-remove": "^2.0.0"
   },
   "license": "MIT",
   "devDependencies": {

--- a/styles/application.scss
+++ b/styles/application.scss
@@ -103,42 +103,22 @@ img[src*="#customer-logo"] {
   }
 }
 
-// heading anchor link styles
-h2,
-h3,
-h4 {
+// page toc
+.app-toc {
+  margin-bottom: govuk-spacing(6);
+}
+
+.app-toc__list-item {
+  list-style-type: none;
   position: relative;
-}
-
-h2 > a,
-h3 > a,
-h4 > a  {
-  position: absolute;
-  display: none;
-  left: -.75em;
-  width: .75em;
-
-  &:focus {
-    outline: 3px solid transparent;
-    color: #0b0c0c;
-    background-color: $govuk-focus-colour;
-    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-text-colour;
-    text-decoration: none;
+  padding-left: govuk-spacing(5);
+  &:before {
+    content: "—";
+    position: absolute;
+    left: 0;
+    width: govuk-spacing(4);
+    overflow: hidden;
   }
-  .icon-link {
-    width: 16px;
-    height: 16px;
-  }
-  .icon-link:after {
-    content: '#';
-    color: $govuk-text-colour;
-  }
-}
-
-h2:hover > a,
-h3:hover > a,
-h4:hover > a  {
-  display: block;
 }
 
 blockquote {


### PR DESCRIPTION
## What

Problem:

DAC audit found that 

> An underlined hash is displayed with mouse hover of the level-two headings on the ‘GOV.UK Platform as a Service’ page. The purpose of the hash is unclear as this only appears to direct users’ focus to the adjacent heading when selected. Also, they are not accessible to standard keyboard commands.

We implemented that feature to allow us to provide deep-links in engagement.

Solution:

Instead on providing this functionality on mouse hover only, we now generate a page table of contents based on headings' IDs, that are anchor links to them. This way we retain the functionality and also make it accessible to everyone.

To generate table of content's we're using [rehype-toc](https://github.com/JS-DevTools/rehype-toc) plugin. 
This generates a TOC on every page, which is undesirable as we don't need one on the homepage, the 404 page, the /sign-in page or any page that doesn't have headings (like /roadmap).

To remove the TOC from those page, we've created a rehype-plugin. We could have created a more comprehensive, own TOC plugin with page exclusions, but that would have taken longer.

Addresses https://www.pivotaltracker.com/n/projects/1275640/stories/174313423

## How to review
- checkout branch
- run `npm install` and visit `localhost:3000`
- run `npm run local`
- look at pages:
 - you should not see a TOC, on homepage, sign-in, 404 or /roadmap (has no headings)
 - you should see TOC on all other pages
- evaluate code

## Visual changes

### Before

link on heading hover
<img width="996" alt="Screenshot 2020-08-23 at 12 27 03" src="https://user-images.githubusercontent.com/3758555/90977261-fb4a4080-e53b-11ea-9316-827138ebc774.png">


### After
<img width="1039" alt="Screenshot 2020-08-23 at 12 25 29" src="https://user-images.githubusercontent.com/3758555/90977242-d05fec80-e53b-11ea-979e-bcaddc497d07.png">
