### PR TITLE
Update main navigation menu label

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -40,7 +40,7 @@ const Header = () => (
     </div>
     <div className="govuk-header__content">
       {Object.keys(data.navigation).length < 1 ? '' : <>
-      <button type="button" className="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <button type="button" className="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation Menu">Menu</button>
       <nav>
         <ul id="navigation" 
           className={`govuk-header__navigation ${data.navigationClasses}`}


### PR DESCRIPTION
Problem:
The aria-label for the 'Menu' button in the header does not include
'menu' despite the button being labelled with the text 'menu'.

This fails WCAG 2.5.3 - Label in name, as flagged in an audit of Digital Marketplace.

Solution:
Add the word 'menu' to the button aria-label