### PR TITLE
Add label to table of contents navigation element

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,7 @@ module.exports = withMdxEnhanced({
       customizeTOC: function(toc) {
         if (toc.type === 'element' && toc.tagName === 'nav') {
           toc.properties.role = 'navigation';
+          toc.properties['aria-label'] = 'Sections on this page';
         }
         if (toc.children[0].children.length === 0) {
           return false


### PR DESCRIPTION
This will make is distinguishable from the main navigation for screenreader users
