### PR TITLE
Increase space between table of content links

### DIFF
--- a/styles/application.scss
+++ b/styles/application.scss
@@ -108,6 +108,10 @@ img[src*="#customer-logo"] {
   margin-bottom: govuk-spacing(6);
 }
 
+.app-toc__link {
+  line-height: 1.5;
+}
+
 .app-toc__list-item {
   list-style-type: none;
   position: relative;


### PR DESCRIPTION
Previous spacing was too tight, especially on mobile