### PR TITLE
Fix failing build for optional props

### DIFF
--- a/components/Footer/data.json
+++ b/components/Footer/data.json
@@ -2,6 +2,7 @@
   "navigation": [
     {
       "title": "Support",
+      "columns": null,
       "items": [
         { 
           "text": "System status", 
@@ -23,6 +24,7 @@
     },
     {
       "title": "Legal terms",
+      "columns": null,
       "items": [
         { 
           "text": "Privacy notice", 
@@ -43,5 +45,9 @@
       ]
     }
   ],
-  "meta": {}
+  "meta" : {
+    "visuallyHiddenTitle" : null,
+    "items": []
+  }
 }
+

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -28,7 +28,7 @@ const Footer = () => (
       <hr className="govuk-footer__section-break"></hr>
       <div className="govuk-footer__meta">
         <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          {Object.keys(meta).length < 1 ? '' : <>
+          {meta.items.length < 1 ? '' : <>
             <h2 className="govuk-visually-hidden">{meta.visuallyHiddenTitle}</h2>
             <ul className="govuk-footer__inline-list">
               {meta.items.map((item, index) => (


### PR DESCRIPTION
## What
To customise the footer items and sections, we use a JSON config file.

We import that file into the component view and populate.
Not all properties are required, but when omitted, Typescript will throw an error.

To mitigate, we now list all properties in the JSON file, but specify a
`null` or empty values.

Additionally checks if the view have been updated so that they don't output any empty markup.

## How to test
- checkout branch
- run `npm run build` to test the build has no errors
- `cd` into `out` directory
- run `npx serve` to serve the static files
- view the page: footer should have the new layout, and there shouldn't be a `govuk-footer__inline-list` element inside `govuk-footer__meta`