### PR TITLE
Link to our channel on cross-gov Slack instance

### DIFF
--- a/components/Footer/data.json
+++ b/components/Footer/data.json
@@ -19,6 +19,10 @@
         { 
           "text": "Roadmap", 
           "href": "https://github.com/alphagov/paas-roadmap/projects/1?fullscreen=true"
+        },
+        { 
+          "text": "Chat to us on Slack", 
+          "href": "https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-paas"
         }
       ]
     },


### PR DESCRIPTION
## What
Link to our channel on cross-gov Slack instance to be consistent with Pay and Notify.

## How to review

- checkout branch
- run `npm run local`
- click on the footer link. if signed into slack it should open the govuk-paas channel