### PR TITLE
Add missing class name to table cell

### DIFF
--- a/pages/cookies.mdx
+++ b/pages/cookies.mdx
@@ -28,7 +28,7 @@ We store session cookies on your computer to help keep your information secure w
     <tr className="govuk-table__row">
       <th scope="row" className="govuk-table__header">JSESSIONID</th>
       <td className="govuk-table__cell">This is set to identify your session</td>
-      <td width="16%">when you close the browser</td>
+      <td className="govuk-table__cell" width="16%">when you close the browser</td>
     </tr>
     <tr className="govuk-table__row">
       <th scope="row" className="govuk-table__header">__VCAP_ID__</th>


### PR DESCRIPTION
Fix missing padding and bottom border on the 'Expires' cell for 'JSESSIONID' within the session cookies table, by adding the same `govuk-table__cell` class used on the other cells.