### PR TITLE
Update cookie banner interaction

### DIFF
--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -1,20 +1,31 @@
 import * as React from 'react'
-import { GridRow, GridColumn } from '@components/GridLayout'
 
 const CookieBanner = () => (
   <div 
-    className="cookie-banner govuk-!-padding-top-3"
-    data-module="cookie-banner"
-    role="region"
-    aria-label="cookie-banner">
-    <div className="govuk-width-container">
-    <GridRow>
-      <GridColumn width='two-thirds'>
-        <h2 className="govuk-heading-m">Can we store analytics cookies on your device?</h2>
-        <p className="govuk-body">Analytics cookies help us understand how our website is being used.</p>
-        <a href="/cookies" className="govuk-button">Set cookie preferences</a>
-      </GridColumn>
-    </GridRow>
+    className="cookie-banner" 
+    data-module="cookie-banner" 
+    role="region" 
+    aria-describedby="cookie-banner__heading"
+  >
+    <div className="cookie-banner__wrapper govuk-width-container">
+      <h2 className="govuk-heading-m" id="cookie-banner__heading">Can we store analytics cookies on your device?</h2>
+      <p className="govuk-body">Analytics cookies help us understand how our website is being used.</p>
+      <div className="cookie-banner__buttons">
+        <button className="govuk-button cookie-banner__button cookie-banner__button-accept" type="submit" data-accept-cookies="true" aria-describedby="cookie-banner__heading">
+          Yes<span className="govuk-visually-hidden">, PaaS can store analytics cookies on your device</span>
+        </button>
+        <button className="govuk-button cookie-banner__button cookie-banner__button-reject" type="submit" data-accept-cookies="false" aria-describedby="cookie-banner__heading">
+          No<span className="govuk-visually-hidden">, PaaS cannot store analytics cookies on your device</span>
+        </button>
+        <a className="govuk-link cookie-banner__link" href="/cookies">How PaaS uses cookies</a>
+      </div>
+    </div>
+
+    <div className="cookie-banner__confirmation govuk-width-container" tabIndex={-1}>
+      <p className="cookie-banner__confirmation-message govuk-body">
+        You can <a className="govuk-link" href="/cookies">change your cookie settings</a> at any time.
+      </p>
+      <button className="cookie-banner__hide-button govuk-link" data-hide-cookie-banner="true" role="link">Hide<span className="govuk-visually-hidden"> cookies message</span></button>
     </div>
   </div>
 )

--- a/javascripts/cookie-functions.js
+++ b/javascripts/cookie-functions.js
@@ -30,9 +30,31 @@ Cookies.prototype.initAnalytics = function() {
 
 Cookies.prototype.initCookieBanner = function ($module) {
   this.$module = $module
+
+  this.$module.hideCookieMessage = this.hideCookieMessage.bind(this)
+  this.$module.showBannerConfirmationMessage = this.showBannerConfirmationMessage.bind(this)
+  this.$module.setBannerCookieConsent = this.setBannerCookieConsent.bind(this)
+  this.$module.cookieBannerConfirmationMessage = this.$module.querySelector('.cookie-banner__confirmation')
+
   if (!this.$module) {
     return
   }
+
+  this.$hideLink = this.$module.querySelector('button[data-hide-cookie-banner]');
+  if (this.$hideLink) {
+    this.$hideLink.addEventListener('click', this.$module.hideCookieMessage);
+  }
+
+  this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies=true]');
+  if (this.$acceptCookiesLink) {
+    this.$acceptCookiesLink.addEventListener('click', () => this.$module.setBannerCookieConsent(true));
+  }
+
+  this.$rejectCookiesLink = this.$module.querySelector('button[data-accept-cookies=false]');
+  if (this.$rejectCookiesLink) {
+    this.$rejectCookiesLink.addEventListener('click', () => this.$module.setBannerCookieConsent(false));
+  }
+
   this.showCookieBanner()
 }
 
@@ -45,6 +67,38 @@ Cookies.prototype.showCookieBanner = function () {
     }
   }
 }
+
+Cookies.prototype.setBannerCookieConsent = function (analyticsConsent) {
+  this.setCookie(this.cookieName, JSON.stringify({ 'analytics': analyticsConsent }), {days: this.cookieDuration})
+
+  this.$module.showBannerConfirmationMessage(analyticsConsent)
+  this.$module.cookieBannerConfirmationMessage.focus()
+
+  if (analyticsConsent) { 
+    this.initAnalytics()
+  }
+}
+
+Cookies.prototype.hideCookieMessage = function (event) {
+  if (this.$module) {
+    this.$module.style.display = 'none'
+  }
+
+  if (event.target) {
+    event.preventDefault()
+  }
+}
+
+Cookies.prototype.showBannerConfirmationMessage = function (analyticsConsent) {
+  var messagePrefix = analyticsConsent ? 'You’ve accepted analytics cookies.' : 'You told us not to use analytics cookies.';
+
+  this.$cookieBannerMainContent = document.querySelector('.cookie-banner__wrapper')
+  this.$cookieBannerConfirmationMessage = document.querySelector('.cookie-banner__confirmation-message')
+
+  this.$cookieBannerConfirmationMessage.insertAdjacentText('afterbegin', messagePrefix)
+  this.$cookieBannerMainContent.style.display = 'none'
+  this.$module.cookieBannerConfirmationMessage.style.display = 'block'
+};
 
 Cookies.prototype.isInCookiesPage = function () {
   return window.location.pathname.indexOf('cookies') > -1

--- a/styles/cookie-banner.scss
+++ b/styles/cookie-banner.scss
@@ -1,3 +1,115 @@
+.cookie-banner__wrapper {
+  @include govuk-responsive-padding(4, "top");
+  @include govuk-responsive-padding(5, "bottom");
+}
+
+// component should only be shown if JS is available, by the cookieMessage JS, so hide by default
 .cookie-banner {
   display: none;
+}
+
+.cookie-banner__buttons {
+  display: flex;
+  flex-wrap: wrap;
+
+  @include govuk-media-query($from: tablet) {
+    flex-wrap: nowrap;
+  }
+}
+
+.cookie-banner__button,
+.cookie-banner__link {
+  vertical-align: baseline;
+}
+
+.cookie-banner__button {
+  display: inline-block;
+  flex: 1 0;
+  padding-left: govuk-spacing(9);
+  padding-right: govuk-spacing(9);
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    flex: 0 0 150px;
+    padding-left: govuk-spacing(2);
+    padding-right: govuk-spacing(2);
+    margin-bottom: govuk-spacing(1);
+  }
+}
+
+.cookie-banner__button-accept {
+  margin-right: govuk-spacing(4);
+}
+
+.cookie-banner__link {
+  @include govuk-font(19);
+  line-height: 1;
+  display: block;
+  width: 100%;
+  padding: 9px 0px 6px;
+
+  @include govuk-media-query($from: tablet) {
+    display: inline;
+    width: auto;
+    margin-left: govuk-spacing(6);
+  }
+}
+
+.cookie-banner__confirmation {
+  display: none;
+  position: relative;
+  padding: govuk-spacing(4) 0;
+
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(4);
+  }
+
+  // This element is focused using JavaScript so that it's being read out by screen readers
+  // for this reason we don't want to show the default outline or emphasise it visually using `govuk-focused-text`
+  &:focus {
+    outline: none;
+  }
+}
+
+.cookie-banner__confirmation-message,
+.cookie-banner__hide-button {
+  display: block;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+  }
+}
+
+.cookie-banner__confirmation-message {
+  margin-right: govuk-spacing(4);
+
+  @include govuk-media-query($from: desktop) {
+    max-width: 90%;
+  }
+}
+
+.cookie-banner__hide-button {
+  @include govuk-font($size: 19);
+  color: $govuk-link-colour;
+  outline: 0;
+  border: 0;
+  background: none;
+  text-decoration: underline;
+  padding: govuk-spacing(0);
+  margin-top: govuk-spacing(2);
+  right: govuk-spacing(3);
+  cursor: pointer;
+
+  @include govuk-media-query($from: desktop) {
+    margin-top: govuk-spacing(0);
+    position: absolute;
+    right: govuk-spacing(4);
+  }
+}
+
+// Additions
+
+// Override margin-bottom, inherited from using .govuk-body class
+.cookie-banner__confirmation-message {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
Add yes/no to quickly accept or deny cookies and initialise GA
Follows Pay and Notify interaction
![Screenshot 2020-12-11 at 14 36 15](https://user-images.githubusercontent.com/3758555/101916069-58870200-3bbe-11eb-9402-fc26562ec8ee.png)


## How to review

- check out branch
- run`npm install`
- set `this.cookieDomain` to empty string for localhost test in cookie-functions.js
- run `npm run local`
- visit http://localhost:3000
- if you haven't set a preference you will see a banner
- save a cookie preference
- check if have cookies stored (chrome: Option + ⌘ + J (on macOS), or Shift + CTRL + J (on Windows/Linux) - Application tab