### PR TITLE
Change to 'appropriate security clearance'

### DIFF
--- a/pages/security.mdx
+++ b/pages/security.mdx
@@ -28,7 +28,7 @@ The platform is designed to meet both the [Cloud Security Principles](/cloud-sec
 
 The platform is built and maintained by a government team within the Government Digital Service, and these are the established working practices:
 
--   everyone with production access has Security Check (SC) clearance
+-   everyone with production access has appropriate security clearance
 -   code changes are approved by team members who haven't worked on the feature
 -   we do pair programming whenever possible
 -   system configuration and access privileges are under source code control and so is documentation


### PR DESCRIPTION
To keep our security details in line with the MoU we are stating 'appropriate security clearance'