### PR TITLE
Implement security headers and Content Security Policy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -54,6 +54,11 @@ http {
   keepalive_timeout 30;
 
   server {
+    set $cspNonceVal $request_id;
+    sub_filter_once off;
+    sub_filter_types *;
+    sub_filter **CSP_NONCE_VAL** $cspNonceVal;
+
     listen {{port}};
     root out;
 
@@ -64,6 +69,7 @@ http {
       add_header X-Content-Type-Options nosniff;
       add_header X-XSS-Protection "0";
       add_header Cache-Control "public, immutable";
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' *.googletagmanager.com/ *.google-analytics.com 'nonce-$cspNonceVal' always; connect-src 'self' *.google-analytics.com; img-src 'self' *.google-analytics.com; font-src 'self' data:;frame-src 'self'; ";
       expires $expires;
     }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -60,6 +60,9 @@ http {
     location / {
       index index.html index.htm;
       error_page 404 /404/index.html;
+      add_header X-Frame-Options SAMEORIGIN;
+      add_header X-Content-Type-Options nosniff;
+      add_header X-XSS-Protection "0";
       add_header Cache-Control "public, immutable";
       expires $expires;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,8 @@ http {
   include nginx/mime.types;
   charset_types text/xml text/plain application/javascript application/rss+xml text/css;
 
+  server_tokens off;
+
   sendfile on;
 
   gzip on;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -41,13 +41,13 @@ class GovukTemplate extends Document {
           <![endif]-->
         `}} />
         <body className="govuk-template__body">
-          <script dangerouslySetInnerHTML={{__html: `document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');`}} />      
+          <script nonce="**CSP_NONCE_VAL**" dangerouslySetInnerHTML={{__html: `document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');`}} />      
           <a href="#main-content" className="govuk-skip-link">Skip to main content</a>
           <CookieBanner />
           <Header />
           <Main />
           <Footer />
-          <script type="text/javascript" src="/assets/javascript/app.js" />
+          <script type="text/javascript" nonce="**CSP_NONCE_VAL**" src="/assets/javascript/app.js" />
         </body>
       </Html>
     )


### PR DESCRIPTION
## What

Implement more security by
- reducing server info
- adding security headers
- implementing a Content Security policy

using nginx configuration. See each commit for detailed explanation.

## Why

Remedial work from the ITHC report, pages 41-46. Also good practice.

## How to review

- review by commit
- check https://paas-product-pages.london.cloudapps.digital/ where this has been deployed to
- accept cookies to check JS is working, check images and fonts are served

## Header comparison
curl -I https://www.cloud.service.gov.uk

content-type: text/html; charset=utf-8
content-length: 16712
accept-ranges: bytes
cache-control: no-cache
cache-control: public, immutable
**server: nginx/1.17.10**
strict-transport-security: max-age=31536000; includeSubDomains; preload
vary: Accept-Encoding


curl -I https://paas-product-pages.london.cloudapps.digital/
HTTP/2 200 

content-type: text/html; charset=utf-8
content-length: 16779
accept-ranges: bytes
cache-control: no-cache
cache-control: public, immutable
**content-security-policy: default-src 'self'; script-src 'self' 'unsafe-inline' .googletagmanager.com/ .google-analytics.com 'nonce-value' always; connect-src 'self' .google-analytics.com; img-src 'self' .google-analytics.com; font-src 'self' data:;frame-src 'self';**
**server: nginx**
strict-transport-security: max-age=31536000; includeSubDomains; preload
vary: Accept-Encoding
**x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 0**