### PR TITLE
Update to govuk-frontend v4.0.0 with required changes

### DIFF
--- a/components/CookieBanner/index.tsx
+++ b/components/CookieBanner/index.tsx
@@ -6,6 +6,7 @@ const CookieBanner = () => (
     data-module="cookie-banner" 
     role="region" 
     aria-describedby="cookie-banner__heading"
+    data-nosnippet
   >
     <div className="cookie-banner__wrapper govuk-width-container">
       <h2 className="govuk-heading-m" id="cookie-banner__heading">Can we store analytics cookies on your device?</h2>

--- a/components/Footer/data.json
+++ b/components/Footer/data.json
@@ -2,6 +2,7 @@
   "navigation": [
     {
       "title": "About GOV.UK PaaS",
+      "width": "one-third",
       "columns": null,
       "items": [
         { 
@@ -48,6 +49,7 @@
     },
     {
       "title": "Support",
+      "width": "one-third",
       "columns": null,
       "items": [
         { 
@@ -74,6 +76,7 @@
     },
     {
       "title": "Legal terms",
+      "width": "one-third",
       "columns": null,
       "items": [
         { 

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -10,7 +10,7 @@ const Footer = () => (
      {navigation.length < 1 ? '' :
         <div className="govuk-footer__navigation">
           {navigation.map((column, index) => (
-            <div key={index} className="govuk-footer__section">
+            <div key={index} className={`govuk-footer__section ${column.width ? `govuk-grid-column-${column.width}` : '`govuk-grid-column-full'}`}>
               <h2 className="govuk-footer__heading govuk-heading-m">{column.title}</h2>
                 <ul className={`govuk-footer__list ${column.columns ? `govuk-footer__list--columns-${column.columns}` : ''}`}>
                   {column.items.map((item, index) => (

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -40,11 +40,10 @@ const Header = () => (
     </div>
     <div className="govuk-header__content">
       {Object.keys(data.navigation).length < 1 ? '' : <>
-      <button type="button" className="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation Menu">Menu</button>
-      <nav>
+      <nav aria-label="Top Level Navigation" className={`govuk-header__navigation ${data.navigationClasses}`}>
+        <button type="button" className="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation Menu">Menu</button>
         <ul id="navigation" 
-          className={`govuk-header__navigation ${data.navigationClasses}`}
-          aria-label="Top Level Navigation"
+          className="govuk-header__navigation-list"
           >
           {data.navigation.map((item, index) => (
             <li key={index} className="govuk-header__navigation-item">

--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -2,6 +2,7 @@
 import common from 'govuk-frontend/govuk/common'
 import Button from 'govuk-frontend/govuk/components/button/button'
 import Header from 'govuk-frontend/govuk/components/header/header'
+import SkipLink from 'govuk-frontend/govuk/components/skip-link/skip-link'
 import Cookies from './cookie-functions'
 import Analytics from './analytics'
 
@@ -33,3 +34,7 @@ var $headers = document.querySelectorAll('[data-module="govuk-header"]')
 nodeListForEach($headers, function ($header) {
   new Header($header).init()
 })
+
+// Find first skip link module to enhance.
+var $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
+new SkipLink($skipLink).init()

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@jsdevtools/rehype-toc": "^3.0.2",
         "@next/mdx": "^12.0.7",
-        "govuk-frontend": "^3.14.0",
+        "govuk-frontend": "^4.0.0",
         "gray-matter": "^4.0.3",
         "next": "^12.0.7",
         "next-mdx-remote": "^3.0.8",
@@ -5163,9 +5163,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -16554,9 +16554,9 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@jsdevtools/rehype-toc": "^3.0.2",
     "@next/mdx": "^12.0.7",
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "^4.0.0",
     "gray-matter": "^4.0.3",
     "next": "^12.0.7",
     "next-mdx-remote": "^3.0.8",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,7 +16,7 @@ class GovukTemplate extends Document {
         <Head />
         <body className='govuk-template__body'>
           <script nonce='**CSP_NONCE_VAL**' dangerouslySetInnerHTML={{ __html: 'document.body.className = ((document.body.className) ? document.body.className + \' js-enabled\' : \'js-enabled\');' }} />
-          <a href='#main-content' className='govuk-skip-link'>Skip to main content</a>
+          <a href='#main-content' className='govuk-skip-link' data-module="govuk-skip-link">Skip to main content</a>
           <CookieBanner />
           <Header />
           <Main />


### PR DESCRIPTION
## What

- update govuk-frontend to v4.0.0
- make changes as per https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0 where needed

## How to test

- check commits for code changes
- clone branch
- install updated dependencies (`npm install`)
- build the site (`npm run build`)
- `cd` into `out` folder and serve the page (`npx serve`)
- check page on `localhost:5000` for any issues

There are [expected warnings in CSS compilation](https://github.com/alphagov/govuk-frontend/issues/2238) coming from govuk-frontend

`npm install` will output 6 high severity vulnerabilities. Currently no fix available for that.