### PR TITLE
Build and run tests on node v16

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
       - run: npm ci
 
       - name: Test

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.5.4"
   },
+  "engines": {
+    "node": "16.x.x",
+    "npm": ">=7.x.x"
+  },
   "standard": {
     "ignore": [
       "out/*"


### PR DESCRIPTION
## What

Build and run tests on node 16, which is now the active LTS version.

As for the production build, it [looks like it's already happening on active LTS](https://github.com/alphagov/paas-release-ci/blob/1e92b932e4cca0dbed7f51132b37cc79a704e070/pipelines/plain_pipelines/paas-product-pages.yml#L34-L41)

[Node docker image with `LTS` tag](https://hub.docker.com/layers/node/library/node/lts/images/sha256-3ab154b75ddea8612aa4669a144f4b8f5ab80e0e1f47a6f835ad93dfe5cb851c?context=explore)

## How to test

- clone branch
- update your version of node to latest LTS (install from [node.js](https://nodejs.org/en/download/) or use nvm)
- install updated dependencies (`npm install`)
- build the site (`npm run build`)
- `cd` into `out` folder and serve the page (`npx serve`)
- check page on `localhost:5000` for any issues

There are [expected warnings in CSS compilation](https://github.com/alphagov/govuk-frontend/issues/2238) coming from govuk-frontend

`npm install` will output 6 high severity vulnerabilities. Currently no fix available for that.

