### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "rehype-slug": "^5.0.1",
-        "sass": "^1.47.0",
+        "sass": "^1.49.0",
         "standard": "^16.0.4"
       },
       "devDependencies": {
@@ -33,11 +33,15 @@
         "jest": "^27.4.7",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.5",
-        "rollup": "^2.63.0",
+        "rollup": "^2.64.0",
         "rollup-plugin-output-manifest": "^2.0.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.5.4"
+      },
+      "engines": {
+        "node": "16.x.x",
+        "npm": ">=8.x.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9706,9 +9710,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-      "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+      "integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -9893,9 +9897,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.47.0.tgz",
-      "integrity": "sha512-GtXwvwgD7/6MLUZPnlA5/8cdRgC9SzT5kAnnJMRmEZQFRE3J56Foswig4NyyyQGsnmNvg6EUM/FP0Pe9Y2zywQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.0.tgz",
+      "integrity": "sha512-TVwVdNDj6p6b4QymJtNtRS2YtLJ/CqZriGg0eIAbAKMlN8Xy6kbv33FsEZSF7FufFFM705SQviHjjThfaQ4VNw==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -18518,9 +18522,9 @@
       }
     },
     "rollup": {
-      "version": "2.63.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-      "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+      "integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -18669,9 +18673,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.47.0.tgz",
-      "integrity": "sha512-GtXwvwgD7/6MLUZPnlA5/8cdRgC9SzT5kAnnJMRmEZQFRE3J56Foswig4NyyyQGsnmNvg6EUM/FP0Pe9Y2zywQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.0.tgz",
+      "integrity": "sha512-TVwVdNDj6p6b4QymJtNtRS2YtLJ/CqZriGg0eIAbAKMlN8Xy6kbv33FsEZSF7FufFFM705SQviHjjThfaQ4VNw==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rehype-slug": "^5.0.1",
-    "sass": "^1.47.0",
+    "sass": "^1.49.0",
     "standard": "^16.0.4"
   },
   "license": "MIT",
@@ -40,7 +40,7 @@
     "jest": "^27.4.7",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.5",
-    "rollup": "^2.63.0",
+    "rollup": "^2.64.0",
     "rollup-plugin-output-manifest": "^2.0.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
@@ -48,7 +48,7 @@
   },
   "engines": {
     "node": "16.x.x",
-    "npm": ">=7.x.x"
+    "npm": ">=8.x.x"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION

## What

Updates: 

- sass
- rollup
- npm min version

## How to test

- clone branch
- install updated dependencies (`npm install`)
- build the site (`npm run build`)
- `cd` into `out` folder and serve the page (`npx serve`)
- check page on `localhost:5000` for any issues

There are [expected warnings in CSS compilation](https://github.com/alphagov/govuk-frontend/issues/2238) coming from govuk-frontend

`npm install` will output 6 high severity vulnerabilities. Currently no fix available for that.