### PR TITLE
Fix sign-in page form styles

### DIFF
--- a/pages/content/sign-in.mdx
+++ b/pages/content/sign-in.mdx
@@ -7,28 +7,18 @@ import Button from '@components/Button'
   <div className="govuk-form-group">
     <fieldset className="govuk-fieldset">
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h2 className="govuk-fieldset__heading">
-          Choose your region
-        </h2>
+        <h2 className="govuk-fieldset__heading">Choose your region</h2>
       </legend>
       <div className="govuk-radios">
         <div className="govuk-radios__item">
           <input className="govuk-radios__input" id="region-london" name="region" type="radio" value="london" defaultChecked={true} aria-describedby="region-london-hint" />
-          <label className="govuk-label govuk-radios__label govuk-label--s" htmlFor="region-london">
-            London
-          </label>
-          <span id="region-london-hint" className="govuk-hint govuk-radios__hint">
-            Apps without a custom domain end with <code>london.cloudapps.digital</code>.
-          </span>
+          <label className="govuk-label govuk-radios__label govuk-label--s" htmlFor="region-london">London</label>
+          <span id="region-london-hint" className="govuk-hint govuk-radios__hint">Apps without a custom domain end with <code>london.cloudapps.digital</code>.</span>
         </div>
         <div className="govuk-radios__item">
           <input className="govuk-radios__input" id="region-ireland" name="region" type="radio" value="ireland" aria-describedby="region-ireland-hint" />
-          <label className="govuk-label govuk-radios__label govuk-label--s" htmlFor="region-ireland">
-            Ireland
-          </label>
-          <span id="region-ireland-item-hint" className="govuk-hint govuk-radios__hint">
-            Apps without a custom domain end with <code>cloudapps.digital</code>.
-          </span>
+          <label className="govuk-label govuk-radios__label govuk-label--s" htmlFor="region-ireland">Ireland</label>
+          <span id="region-ireland-item-hint" className="govuk-hint govuk-radios__hint"> Apps without a custom domain end with <code>cloudapps.digital</code>.</span>
         </div>
       </div>
     </fieldset>


### PR DESCRIPTION
# What

Fix sign-in page form styles
markdown parser has new rules that adds `<p>` tag if empty space

## before
![Screenshot 2022-02-21 at 16 05 32](https://user-images.githubusercontent.com/3758555/155012592-f77d5c52-e0d6-481a-9ecf-a2570fe78e5c.png)


## after
![Screenshot 2022-02-21 at 16 05 46](https://user-images.githubusercontent.com/3758555/155012611-9b952421-13fd-4b8f-a06f-cb20c6812ff2.png)
