### PR TITLE
Remove white space around button text

### DIFF
--- a/pages/content/pricing.mdx
+++ b/pages/content/pricing.mdx
@@ -18,9 +18,7 @@ You can adjust the amount of resources you are using at any time, depending on w
   data-track-click="true"
   data-track-category="Navigation"
   data-track-action="Button Click"
-  data-track-label="Calculate the costs">
-    Calculate the costs
-</Button>
+  data-track-label="Calculate the costs">Calculate the costs</Button>
 
 The price we charge includes a 10% service fee to cover the internal overhead of procuring and making these resources available to you, and making sure the platform complies with information assurance standards.
 


### PR DESCRIPTION
Removing the white space stops markdown creating a paragraph which affects the browser rendering.