### PR TITLE
Use hash for CSP

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -54,11 +54,6 @@ http {
   keepalive_timeout 30;
 
   server {
-    set $cspNonceVal $request_id;
-    sub_filter_once off;
-    sub_filter_types *;
-    sub_filter **CSP_NONCE_VAL** $cspNonceVal;
-
     listen {{port}};
     root out;
 
@@ -69,7 +64,7 @@ http {
       add_header X-Content-Type-Options nosniff;
       add_header X-XSS-Protection "0";
       add_header Cache-Control "public, immutable";
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'nonce-$cspNonceVal' always; connect-src 'self'; img-src 'self'; font-src 'self' data:;frame-src 'self'; ";
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' always; connect-src 'self'; img-src 'self'; font-src 'self' data:;frame-src 'self'; ";
       add_header Permissions-Policy "interest-cohort=()";
       expires $expires;
     }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -17,12 +17,12 @@ class GovukTemplate extends Document {
         <link href={`/assets/styles/${styleSheetHash['application.css']}`} rel='stylesheet' />
         </Head>
         <body className='govuk-template__body'>
-          <script nonce='**CSP_NONCE_VAL**' dangerouslySetInnerHTML={{ __html: 'document.body.className = ((document.body.className) ? document.body.className + \' js-enabled\' : \'js-enabled\');' }} />
+          <script dangerouslySetInnerHTML={{ __html: 'document.body.className = ((document.body.className) ? document.body.className + \' js-enabled\' : \'js-enabled\');' }} />
           <a href='#main-content' className='govuk-skip-link' data-module="govuk-skip-link">Skip to main content</a>
           <Header />
           <Main />
           <Footer />
-          <script type='text/javascript' nonce='**CSP_NONCE_VAL**' src={`/assets/javascript/${javascriptHash['application.js']}`} />
+          <script type='text/javascript' src={`/assets/javascript/${javascriptHash['application.js']}`} />
           <NextScript />
         </body>
       </Html>


### PR DESCRIPTION
## What
In https://github.com/alphagov/paas-product-pages/pull/117 we implemented Content security policy (CSP) with a generated nonce value as using a hash didn't work.

Now using a hash works, so we can remove the generated nonce value and use the govuk-frontend provided SHA - https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#use-a-hash-to-unblock-inline-javascript

## How to test

- requirement Docker Desktop
- clone and build `npm run build`
- start Docker Desktop
- run `npm run nginx:local`
- visit `http://localhost:8080`
- check no error in dev tools console and javascript still works - shrink to mobile view and check header menu toggle)