### PR TITLE
Redirect /roadmap to /

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -90,5 +90,9 @@ http {
       return 301 https://vdp.cabinetoffice.gov.uk/.well-known/security.txt;
     }
 
+    location = /roadmap {
+      return 301 /;
+    }
+
   }
 }


### PR DESCRIPTION
## What
Redirect /roadmap to /
We have decommissioned the roadmap and we don;t want to serve a 404 page

## How to test
- requirement Docker Desktop
- clone and build `npm run build`
- start Docker Desktop
- run `npm run nginx:local`
- visit `http://localhost:8080/roadmap`