### PR TITLE
Remove section on trial accounts and upgrades

### DIFF
--- a/pages/content/pricing.mdx
+++ b/pages/content/pricing.mdx
@@ -24,17 +24,6 @@ included in this price are:
 -   a user friendly administration tool for managing your organisations, users, applications and billing
 -   full access to all the [features of the platform](/features)
 
-## How to start using the paid service
-
-We offer a free trial account to help you evaluate the platform. A trial account offers limited features and lasts for 3 months.
-
-To start using the paid service, your organisations will need to sign a Crown or non-Crown Memorandum of Understanding (MOU) with Government Digital Service depending on the type of organisation the service belongs to. Contact us to find out if your organisation has signed an MOU, or to get a copy.
-
-Once your department has signed an MOU, you will need to:
-
--   [add a Billing Manager to your GOV.UK PaaS organisation](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles), who can authorise and manage payment for the service
--   email [gov-uk-paas-support@digital.cabinet-office.gov.uk](mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk) to request a paid account, copying in your Billing Manager. They will need to authorise the request.
-
 ## How to pay
 
 When you start using the paid service, we will ask you to estimate your annual spend and send us a purchase order. After that we will send you regular invoices.


### PR DESCRIPTION
Remove "How to start using the paid service" section from the /pricing page
It talks about trial accounts and option to upgrade