### PR TITLE
Remove link to performance dashboard

### DIFF
--- a/components/Footer/data.json
+++ b/components/Footer/data.json
@@ -49,10 +49,6 @@
           "href": "https://status.cloud.service.gov.uk"
         },
         { 
-          "text": "Performance dashboard", 
-          "href": "https://admin.london.cloud.service.gov.uk/performance"
-        },
-        { 
           "text": "Documentation", 
           "href": "https://docs.cloud.service.gov.uk"
         },


### PR DESCRIPTION
It's going away in https://www.pivotaltracker.com/story/show/183022217