### PR TITLE
Update to node v18

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     env:
       NODE_ENV: development

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript": "^4.9.4"
       },
       "engines": {
-        "node": "16.x.x",
+        "node": "18.x.x",
         "npm": ">=8.x.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.9.4"
   },
   "engines": {
-    "node": "16.x.x",
+    "node": "18.x.x",
     "npm": ">=8.x.x"
   },
   "standard": {


### PR DESCRIPTION
V18 is now LTS so it makes sense to upgrade.
[requires a move to ubuntu 20 build on GHA](https://github.com/alphagov/paas-product-pages/actions/runs/3829737255/jobs/6516761409#step:4:8)