### PR TITLE
Add finalising guidance section

### DIFF
--- a/pages/content/migration-guidance.mdx
+++ b/pages/content/migration-guidance.mdx
@@ -535,12 +535,11 @@ The GOV.UK PaaS team will then:
 </ol>
 
 If you notify us that one of your services is decommissioned but the PaaS team discovers that you still have running apps and backing services, we will:
-  - send you a reminder to delete the apps and backing services
-  - wait a week and if you still have running apps we will stop the apps and send another reminder to delete the apps and services
-  - wait a week and unless you have notified us otherwise we will delete the apps and the backing services
-
-
-
+<ol class="govuk-list govuk-list--number">
+<li>send you a reminder to delete the apps and backing services</li>
+<li>wait a week and if you still have running apps we will stop the apps and send another reminder to delete the apps and services</li>
+<li>wait a week and unless you have notified us otherwise we will delete the apps and the backing services</li>
+</ol>
 
 ## How to contact us
 


### PR DESCRIPTION
Add a new section explaining to tenants how to finalise their account, deleting apps and services and what the paas team will do in return

# to review
- ensure it reads ok
- ensure links to external resources work
