### PR TITLE
Use latest builpack in cf manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: paas-product-pages
-    buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
+    buildpack: nginx_buildpack
     memory: 256M
     instances: 2
     stack: cflinuxfs3


### PR DESCRIPTION
update to use latest non-pinned nginx buildpack

resolves  https://concourse.build.ci.cloudpipeline.digital/builds/62003569