### PR TITLE
Require node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "typescript": "^5.2.2"
   },
   "engines": {
-    "node": "18.x.x",
-    "npm": ">=8.x.x"
+    "node": "20.x.x",
+    "npm": ">=10.x.x"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Node 20.9.0 is the new LTS https://nodejs.org/en/blog/release/v20.9.0 and 18 has gone into maintenance.

We deploy static pages anyway so it doesn't matter too much, but still good practice to use LTS 